### PR TITLE
updated gov and committer titles

### DIFF
--- a/COMMITTERS.csv
+++ b/COMMITTERS.csv
@@ -1,14 +1,14 @@
 **Committers**,,,,,,,,,,,,
 Name,Email,GitHub ID,Role,Com Repo,Spark Repo,gvblib Repo,Res Repo,Doc Repo,PE Repo,RC Repo,WB Repo,Test Repo
-Kip Twitchell,kip.twitchell@us.ibm.com,KipTwitchell,Community,X,X,,,,,,,
+Kip Twitchell,kip.twitchell@us.ibm.com,KipTwitchell,TSC Chair,X,X,,,,,,,
 Randall Ness,rhness@us.ibm.com,rhness,Solution architect,,X,X,X,X,X,X,X,X
 Bob McCormack,bobmcc@au1.ibm.com,bobmcc9,Build lead,X,X,X,X,X,X,X,X,X
-Andrea Orth,spookykitty93@outlook.com,AOrthVector,Scrum Master and Assistant DM,X,,,,X,,,,
+Andrea Orth,spookykitty93@outlook.com,AOrthVector,TSC Secretary Webmaster Scum Master,X,,,,X,,,,
 Gill Hannington,ghannington2007@gmail.com,ghannington,Performance Engine lead,,,X,X,,X,,,
 Ian Cunningham,blueham60@gmail.com,hammyau,Workbench lead,,,,X,,,X,X,X
-Sandy Peresie,speresie1@yahoo.com,SaPeresi,Python Developer and Spark DM,,X,,,,,,,
+Sandy Peresie,speresie1@yahoo.com,SaPeresi,Integration architect-OSS,,X,,,,,,,
 Rakesh Kant,,rkant0721,Apache Spark integration,,X,,,,,,,
-Jeff Horner,,jhornert,Integration architect,,X,X,X,X,X,X,X,X
+Jeff Horner,,jhornert,Integration architect-WB and PE,,X,X,X,X,X,X,X,X
 Eugene Morrow,,emorrow38,Documentation lead,,,,,X,,,,
 Jim Hladyshewsky,jim.hladyshewsky@us.ibm.com,JIMHLADYSHEWSKY,Delivery Manager,X,,,,,,,,
 Elana Dunn,,elanadunn,Assistant DM,X,,,,,,,,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -52,6 +52,7 @@ The Delivery Manager is responsible for development plans, end-user coordination
 It is proposed that The GenevaERS Project committers compose the initial Technical Steering Committee (TSC):
 
 * Chair
+* TSC Secretary and Webmaster
 * Solution architect
 * Performance Engine lead
 * Workbench lead


### PR DESCRIPTION
Updated Gov. by adding Andrea and Sandy to TSC as they are effectively working in those jobs.  Also updated titles in Committer Doc.  Signed-off-by: KipTwitchell <kip.twitchell@us.ibm.com>